### PR TITLE
Multiple fixes for image uploading

### DIFF
--- a/application/config/MY_constants.php
+++ b/application/config/MY_constants.php
@@ -72,3 +72,10 @@ define('DATABASE_DATETIME_FORMAT', 'Y-m-d H:i:s');
  */
 define('IMAGE_UPLOAD_WIDTH', 360);
 define('IMAGE_UPLOAD_HEIGHT', 360);
+
+/*
+ |-------------------------------------------------------------------------
+ | NULL image name
+ |-------------------------------------------------------------------------
+ */
+define('DEFAULT_IMAGE_NAME', 'no_image.png');

--- a/application/controllers/Item.php
+++ b/application/controllers/Item.php
@@ -413,6 +413,7 @@ class Item extends MY_Controller {
 
             $data['modify'] = true;
             $data['item_id'] = $id;
+            $_SESSION['item_id'] = $id;
 
             // Load the options
             $this->load->model('stocking_place_model');
@@ -434,7 +435,7 @@ class Item extends MY_Controller {
             // If the user gets back from another view, get the fields values
             // which have been saved in session variable.
             // Then reset this session variable.
-            if(isset($_SESSION['POST'])){
+            if(isset($_SESSION['POST']) && ($_SESSION['submit_image'] ?? FALSE)) {
                 foreach ($_SESSION['POST'] as $key => $value) {
                     // If it is a tag
                     if (substr($key, 0, 3) == "tag") {
@@ -446,8 +447,9 @@ class Item extends MY_Controller {
                         $data[$key] = $value;
                     }
                 }
-                unset($_SESSION['POST']);
             }
+            $_SESSION['submit_image'] = FALSE;
+            unset($_SESSION['POST']);
             
             $this->display_view('item/form', $data);
         } else {

--- a/application/controllers/Picture.php
+++ b/application/controllers/Picture.php
@@ -51,14 +51,24 @@ class Picture extends MY_Controller {
             $this->set_validation_rules();
             
             if($this->form_validation->run()){
+                /*
+                 This will cause problems if someone is uploading multiple images at once.
+                 But then, a bunch of other things will also break, so...
+                */
+                $id = $_SESSION['item_id'];
                 
                 $picture_file = $_POST['cropped_file'];
                 $picture_name = $_POST['cropped_name'];
                 
-                file_put_contents("uploads/images/$picture_name", base64_decode(preg_replace('#^data:image/\w+;base64,#i', '', $picture_file)));
+                // Make sure the picture starts with {id}_
+                if (!preg_match('/^'.$id.'_/', $picture_name)) {
+                    $picture_name = $id.'_'.$picture_name;
+                    $_POST['cropped_name'] = $picture_name;
+                }
+                file_put_contents("uploads/images/{$picture_name}", base64_decode(preg_replace('#^data:image/\w+;base64,#i', '', $picture_file)));
                 
-                $_SESSION['picture_path'] = $picture_name;
-                
+                $_SESSION['POST']['image'] = $picture_name;
+                $_SESSION['submit_image'] = TRUE;
                 redirect($_SESSION['picture_callback']);
                 exit();
                 

--- a/application/models/Item_model.php
+++ b/application/models/Item_model.php
@@ -78,16 +78,14 @@ class Item_model extends MY_Model
     }
 
     /**
-    * If no image is set, use "no_image.png"
+    * If no image is set, use DEFAULT_IMAGE_NAME constant
     */
     protected function get_image($item)
     {		
-        if (!is_null($item)) {
-			if (is_null($item->image))
-			{
-				$item->image = 'no_image.png';
-			}
-		}
+        if (!is_null($item) && is_null($item->image))
+        {
+            $item->image = DEFAULT_IMAGE_NAME;
+        }
 
         return $item;
     }

--- a/application/views/item/select_photo.php
+++ b/application/views/item/select_photo.php
@@ -1,3 +1,10 @@
+<?php
+// Make sure the user cannot modify the default image
+$image = $_SESSION['POST']['image'] ?? '';
+if ($image == DEFAULT_IMAGE_NAME) {
+    $image = '';
+}
+?>
 <form id="form" class="container" method="post" action="add_picture" >
     <?php if (isset($upload_error)) { ?>
     <div class="row alert alert-danger"><?=$upload_error?></div>
@@ -59,10 +66,10 @@ const IMAGE_UPLOAD_HEIGHT = <?= IMAGE_UPLOAD_HEIGHT; ?>;
 //
 function reSelectPhoto(event)
 {
-    var path = "<?= isset($_SESSION['POST']['image']) && !empty($_SESSION['POST']['image'])? $_SESSION['POST']['image'] : "" ?>";
+    var path = "<?= $image ?>";
     
     if(path !== ""){
-        rawImage.src = "<?= base_url("uploads/images/".$_SESSION['POST']['image'])?>";
+        rawImage.src = "<?= base_url("uploads/images/{$image}")?>";
         croppedNameInput.value = path;
         setCropper();
     }


### PR DESCRIPTION
List of changes:

- New constant for default image name.
- Item now double verifies that an image has been uploaded and saves the curent item id in `$_SESSION['item_id']`.
- Picture now puts the image's id before its name if it's not already there.
- `Item_model::get_image` now uses the constant.
- select_photo form now prevents display of the cropper if there is no image.

Closes #114, #107, #106